### PR TITLE
fix(ci): restore build.yml trailing newline and renamed build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,4 +18,4 @@ jobs:
       contents: read
     steps:
       - name: NextJS Build
-        uses: p6m7g8-actions/next-build@main
+        uses: p6m7g8-actions/p6-next-build@main


### PR DESCRIPTION
See commit message. Restores the trailing newline yamllint requires, and re-applies the build-action rename that the distribution merge reverted. The queue-ref trigger is preserved.